### PR TITLE
Fix warning during import of OGB in Cluster GCN

### DIFF
--- a/gnn-cluster-gcn/requirements.txt
+++ b/gnn-cluster-gcn/requirements.txt
@@ -1,6 +1,6 @@
 metis==0.2a5
 networkx==2.5.1
-ogb==1.3.3
+ogb==1.3.5
 plotly==5.7.0
 pydantic==1.9.0
 pytest==6.2.5

--- a/ogb-competition/pcqm4mv2_submission/README.md
+++ b/ogb-competition/pcqm4mv2_submission/README.md
@@ -10,7 +10,7 @@ This model is optimised for Graphcore IPUs and requires the Graphcore's Poplar S
 
 #### Running on Paperspace
 
-The Paperspace environment lets you run this notebook with no set up. To improve your experience we preload datasets and pre-install packages, this can take a few minutes, if you experience errors immediately after starting a session please try restarting the kernel before contacting support. If a problem persists or you want to give us feedback on the content of this notebook, please reach out to through our community of developers using our [slack channel](graphcorecommunity.slack.com) or raise a [GitHub issue](https://github.com/gradient-ai/Graphcore-Tensorflow2/issues).
+The Paperspace environment lets you run this notebook with no set up. To improve your experience we preload datasets and pre-install packages, this can take a few minutes, if you experience errors immediately after starting a session please try restarting the kernel before contacting support. If a problem persists or you want to give us feedback on the content of this notebook, please reach out to through our community of developers using our [slack channel](https://graphcorecommunity.slack.com) or raise a [GitHub issue](https://github.com/gradient-ai/Graphcore-Tensorflow2/issues).
 
 
 Install the requirements:


### PR DESCRIPTION
We had a report of a warning due to an old version of a package.

I ran through the notebook on paperspace with the new version and it ran correctly so I suggest we bump the version.